### PR TITLE
Open connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 language: go
 
 go:
-  - "1.9"
   - "1.10"
   - "1.11"
   - "1.12"

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.4.1-0.20191114115753-b4242bab7dc5 h1:TPdJVmaDpKVlxYKc2CTaU6iY51jeQqbRooWdI1ATYG4=
 github.com/go-sql-driver/mysql v1.4.1-0.20191114115753-b4242bab7dc5/go.mod h1:XIaZU7xtUgusUqDPXOOPcmC5Dyyw3F1pbh54fHzaehk=
+github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5 h1:lrdPtrORjGv1HbbEvKWDUAy97mPpFm4B8hp77tcCUJY=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.2.1-0.20191011153232-f91d3411e481 h1:r9fnMM01mkhtfe6QfLrr/90mBVLnJHge2jGeBvApOjk=
 github.com/lib/pq v1.2.1-0.20191011153232-f91d3411e481/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.13.0 h1:LnJI81JidiW9r7pS/hXe6cFeO5EXNq7KbfvoJLRI69c=
 github.com/mattn/go-sqlite3 v1.13.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=

--- a/mssqlx.go
+++ b/mssqlx.go
@@ -1437,7 +1437,7 @@ func (dbs *DBs) BeginTxx(ctx context.Context, opts *sql.TxOptions) (res *sqlx.Tx
 	}
 }
 
-// ConnectMasterSlaves to master-slave databases and verify with pings.
+// ConnectMasterSlaves to master-slave databases, healthchecks will ensure they are working
 // driverName: mysql, postgres, etc.
 // masterDSNs: data source names of Masters.
 // slaveDSNs: data source names of Slaves.
@@ -1485,7 +1485,7 @@ func ConnectMasterSlaves(driverName string, masterDSNs []string, slaveDSNs []str
 	n := 0
 	for i := range masterDSNs {
 		go func(mId, eId int) {
-			dbConn, err := sqlx.Connect(driverName, masterDSNs[mId])
+			dbConn, err := sqlx.Open(driverName, masterDSNs[mId])
 			dbs._masters[mId], errResult[eId] = &wrapper{db: dbConn, dsn: masterDSNs[mId]}, err
 			dbs.masters.add(dbs._masters[mId])
 
@@ -1500,7 +1500,7 @@ func ConnectMasterSlaves(driverName string, masterDSNs []string, slaveDSNs []str
 	// Concurrency connect to slaves
 	for i := range slaveDSNs {
 		go func(sId, eId int) {
-			dbConn, err := sqlx.Connect(driverName, slaveDSNs[sId])
+			dbConn, err := sqlx.Open(driverName, slaveDSNs[sId])
 			dbs._slaves[sId], errResult[eId] = &wrapper{db: dbConn, dsn: slaveDSNs[sId]}, err
 			dbs.slaves.add(dbs._slaves[sId])
 

--- a/mssqlx_test.go
+++ b/mssqlx_test.go
@@ -371,10 +371,17 @@ func TestConnectMasterSlave(t *testing.T) {
 		t.Fatal("Ping fail")
 	}
 
+	// ensure no nil dbs
+	for _, v := range db._all {
+		if v.db == nil {
+			t.Fatal("Nil DB in list")
+		}
+	}
+
 	// test another ping
 	for _, v := range db._all {
-		if v.db != nil && ping(v) != nil {
-			t.Fatal("Ping fail")
+		if e := ping(v); e != nil && e.Error() != "pq: role \"test1\" does not exist" {
+			t.Fatal(e)
 		}
 	}
 


### PR DESCRIPTION
As mentioned [here,](https://github.com/linxGnu/mssqlx/issues/1) `sqlx.Connect` returns `nil` when the `Ping()` fails, while Open will create the connection.
The mssqlx healthcheck will ensure that only alive connections are used to perform queries.