### PR TITLE
Add an option to distribute reads among all nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.14.3
+
+WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+ADD . .
+
+CMD go test -count=1 -v -race ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+test:
+	docker-compose -f docker-compose.yml up --build --abort-on-container-exit
+	docker-compose -f docker-compose.yml down --volumes

--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ db, _ := mssqlx.ConnectMasterSlaves("mysql", masterDSNs, slaveDSNs)
 Recommended to set flag as following: 
 
 ```go
-db, _ := mssqlx.ConnectMasterSlaves("mysql", masterDSNs, slaveDSNs, true)
+db, _ := mssqlx.ConnectMasterSlaves("mysql", masterDSNs, slaveDSNs, mssqlx.WithWsrep())
+```
+
+## Connecting to Databases with custom read-query source
+
+Read-queries will be distributed among both masters and slaves: 
+
+```go
+db, _ := mssqlx.ConnectMasterSlaves("mysql", masterDSNs, slaveDSNs, mssqlx.WithReadQuerySource(mssqlx.ReadQuerySourceAll))
 ```
 
 ## Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+networks:
+  integration-test:
+    driver: bridge
+services:
+  postgres:
+    image: postgres:9.6
+    expose:
+      - "5432"
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test
+    restart: on-failure
+    networks:
+      - integration-test
+  mysql:
+    image: mysql:5.7
+    expose:
+      - "3306"
+    environment:
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: test
+    restart: on-failure
+    networks:
+      - integration-test
+  mssqlx:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      MSSQLX_POSTGRES_DSN: host=postgres user=test password=test dbname=test sslmode=disable
+      MSSQLX_MYSQL_DSN: test:test@tcp(mysql:3306)/test
+    depends_on:
+      - postgres
+      - mysql
+    networks:
+      - integration-test

--- a/options.go
+++ b/options.go
@@ -1,0 +1,35 @@
+package mssqlx
+
+type ReadQuerySource int
+
+const (
+	// ReadQuerySourceSlaves indicates: read-queries will be distributed only among slaves.
+	// This is default value.
+	//
+	// Note: there is no option for Master. One could use functions like `QueryMaster`, etc
+	// to query from masters only.
+	ReadQuerySourceSlaves ReadQuerySource = iota
+	// ReadQuerySourceAll indicates: read-queries will be distributed among both masters and slaves.
+	ReadQuerySourceAll
+)
+
+type clusterOptions struct {
+	isWsrep         bool
+	readQuerySource ReadQuerySource
+}
+
+type Option func(*clusterOptions)
+
+// WithWsrep indicates galera/wsrep cluster
+func WithWsrep() Option {
+	return func(o *clusterOptions) {
+		o.isWsrep = true
+	}
+}
+
+// WithReadQuerySource sets default sources for read-queries.
+func WithReadQuerySource(source ReadQuerySource) Option {
+	return func(o *clusterOptions) {
+		o.readQuerySource = source
+	}
+}


### PR DESCRIPTION
In my current setup I have 1 master and 1 slave with 90% of read operations and 10% of write operations. This means that the resources of the host are not being used properly. The idea is to have and option to distribute read requests between the master and slave.